### PR TITLE
Require space in {{t and (t tags

### DIFF
--- a/lib/lex.js
+++ b/lib/lex.js
@@ -30,7 +30,7 @@ module.exports = function tokenize(source) {
         lexer = new Lexer(function() {});
 
     // {{t 'Translate me'}}
-    lexer.addRule(/\{\{t.+?\s*\}\}/g, function(lexeme) {
+    lexer.addRule(/\{\{\s+t.+?\s*\}\}/g, function(lexeme) {
         var str = extract(lexeme);
         tokens.push(unescape(str));
     }, []);
@@ -44,7 +44,7 @@ module.exports = function tokenize(source) {
     }, []);
 
     // {{input placeholder=(t 'Translate me')}}
-    lexer.addRule(/\(t.+?\s*\)/g, function(lexeme) {
+    lexer.addRule(/\(t\s+.+?\s*\)/g, function(lexeme) {
         var str = extract(lexeme);
         tokens.push(unescape(str));
     }, []);


### PR DESCRIPTION
This fixes {{task-thing title=(t "hoera")} top be missed because {{t matches.